### PR TITLE
sketch: text editor mode for nub-bindings-editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.4",
 			"license": "MIT",
 			"dependencies": {
-				"@chasemoskal/magical": "^0.0.4",
+				"@chasemoskal/magical": "^0.0.5",
 				"lit": "^2.4.1"
 			},
 			"devDependencies": {
@@ -120,9 +120,9 @@
 			}
 		},
 		"node_modules/@chasemoskal/magical": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/@chasemoskal/magical/-/magical-0.0.4.tgz",
-			"integrity": "sha512-51Acijt0xOw3PS2qC6nMQpx+FwcgJNRNl0seOHj+0zaImv1wduGpTQkoZICmf6zRn2aK6b0K5jIPPNtAIh2GNA==",
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/@chasemoskal/magical/-/magical-0.0.5.tgz",
+			"integrity": "sha512-78naKVYVbbbZbeVPLEGK+DO7gHTl8kNu3A+vvneRuVVGK5pVpfvcWtHGVdXuu/Zj2+0oSuN4RPbhGRVqD3QUHA==",
 			"dependencies": {
 				"es-module-shims": "^1.6.2"
 			},
@@ -2243,9 +2243,9 @@
 			}
 		},
 		"@chasemoskal/magical": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/@chasemoskal/magical/-/magical-0.0.4.tgz",
-			"integrity": "sha512-51Acijt0xOw3PS2qC6nMQpx+FwcgJNRNl0seOHj+0zaImv1wduGpTQkoZICmf6zRn2aK6b0K5jIPPNtAIh2GNA==",
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/@chasemoskal/magical/-/magical-0.0.5.tgz",
+			"integrity": "sha512-78naKVYVbbbZbeVPLEGK+DO7gHTl8kNu3A+vvneRuVVGK5pVpfvcWtHGVdXuu/Zj2+0oSuN4RPbhGRVqD3QUHA==",
 			"requires": {
 				"es-module-shims": "^1.6.2"
 			}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"test": "exit 0"
 	},
 	"dependencies": {
-		"@chasemoskal/magical": "^0.0.4",
+		"@chasemoskal/magical": "^0.0.5",
 		"lit": "^2.4.1"
 	},
 	"devDependencies": {

--- a/s/elements/bindings-editor/style.css.ts
+++ b/s/elements/bindings-editor/style.css.ts
@@ -7,10 +7,36 @@ export const styles = css`
 	display: block;
 	font-family: monospace;
 	background: #111e;
+	color: #fffc;
 	--outline-soft: #fff4;
 	--outline-hard: #fff8;
 	--pad-keygap: 0.4em;
 	--pad-keyinner: 0.2em;
+}
+
+.metabar {
+	padding: 0.1em 0.5em;
+	button {
+		background: transparent;
+		border: none;
+		color: inherit;
+		opacity: 0.7;
+		cursor: pointer;
+		^:is(:hover) { opacity: 1; }
+	}
+}
+
+[data-panel="text-editor"] {
+	padding: 1em;
+
+	textarea {
+		width: 100%;
+		min-height: 24em;
+		background: #0007;
+		color: #fffa;
+		border: 0;
+		padding: 1em;
+	}
 }
 
 .keybindlist {

--- a/s/elements/bindings-editor/types.ts
+++ b/s/elements/bindings-editor/types.ts
@@ -3,3 +3,7 @@ export interface Waiting {
 	action: string
 	keyIndex: number
 }
+
+export interface AssignKeybind {
+	(action: string, keyIndex: number, keyCode: string): void
+}

--- a/s/elements/bindings-editor/utils/prepare-assign-keybind.ts
+++ b/s/elements/bindings-editor/utils/prepare-assign-keybind.ts
@@ -1,0 +1,27 @@
+
+import {AssignKeybind} from "../types.js"
+import {Bindings} from "../../../types.js"
+import {NubContext} from "../../context/element.js"
+
+export function prepareAssignKeybind(context: NubContext): AssignKeybind {
+	return function assignKeyBind(
+			action: string,
+			keyIndex: number,
+			code: string,
+		) {
+
+		const bindings = <Bindings>structuredClone(context.getBindings())
+		const notRedundant = !bindings["*️⃣"][action].some(c => c === code)
+
+		if (notRedundant) {
+			const isEscapeKey = code === "Escape"
+
+			if (isEscapeKey)
+				bindings["*️⃣"][action].splice(keyIndex, 1)
+			else
+				bindings["*️⃣"][action][keyIndex] = code
+
+			context.updateBindings(bindings)
+		}
+	}
+}

--- a/s/elements/bindings-editor/utils/setup-listen-to-inputs-and-actuate-key-bind-assignment.ts
+++ b/s/elements/bindings-editor/utils/setup-listen-to-inputs-and-actuate-key-bind-assignment.ts
@@ -1,54 +1,35 @@
 
+import {Nub} from "../../../types.js"
+import {AssignKeybind, Waiting} from "../types.js"
+import {NubInputEvent} from "../../../events/input.js"
+import {setupEventListener} from "./setup-event-listeners.js"
 import {StateSetter} from "@chasemoskal/magical/x/view/types.js"
 
-import {Waiting} from "../types.js"
-import {Bindings, Nub} from "../../../types.js"
-import {NubInputEvent} from "../../../events/input.js"
-import {NubContext} from "../../context/element.js"
-import {setupEventListener} from "./setup-event-listeners.js"
-
 export function setupListenToInputsAndActuateKeyBindAssignment({
-		context,
+		eventTarget,
 		getWaiting,
 		setWaiting,
+		onKeybindAssignment,
 	}: {
-		context: NubContext
+		eventTarget: EventTarget
+		onKeybindAssignment: AssignKeybind
 		getWaiting: () => undefined | Waiting
 		setWaiting: StateSetter<undefined | Waiting>
 	}) {
 
-	return () => {
-
-		function assignKeyBind(
-				action: string,
-				keyIndex: number,
-				code: string,
-			) {
-			setWaiting(undefined)
-			const bindings = <Bindings>structuredClone(context.getBindings())
-			const notRedundant = !bindings["*️⃣"][action].some(c => c === code)
-			if (notRedundant) {
-				const isEscapeKey = code === "Escape"
-				if (isEscapeKey)
-					bindings["*️⃣"][action].splice(keyIndex, 1)
-				else
-					bindings["*️⃣"][action][keyIndex] = code
-				context.updateBindings(bindings)
-			}
-		}
-
-		return setupEventListener<NubInputEvent>(
-			context,
-			NubInputEvent,
-			event => {
-				const waiting = getWaiting()
-				if (waiting && event.detail.type === Nub.Type.Key) {
-					const {code, pressed} = event.detail
-					const {action, keyIndex} = waiting
-					if (pressed)
-						assignKeyBind(action, keyIndex, code)
+	return () => setupEventListener<NubInputEvent>(
+		eventTarget,
+		NubInputEvent,
+		event => {
+			const waiting = getWaiting()
+			if (waiting && event.detail.type === Nub.Type.Key) {
+				const {code, pressed} = event.detail
+				const {action, keyIndex} = waiting
+				if (pressed) {
+					onKeybindAssignment(action, keyIndex, code)
+					setWaiting(undefined)
 				}
-			},
-		)
-	}
+			}
+		},
+	)
 }

--- a/s/elements/bindings-editor/views/easy-editor-panel.ts
+++ b/s/elements/bindings-editor/views/easy-editor-panel.ts
@@ -1,0 +1,51 @@
+
+import {html} from "lit"
+import {view} from "@chasemoskal/magical/x/view/view.js"
+
+import {Bindings} from "../../../types.js"
+import {hackGetter} from "./easy/hack-getter.js"
+import {buttonLabels} from "../utils/constants.js"
+import {AssignKeybind, Waiting} from "../types.js"
+import {renderKeybind} from "./easy/render-keybind.js"
+import {setupListenToInputsAndActuateKeyBindAssignment} from "../utils/setup-listen-to-inputs-and-actuate-key-bind-assignment.js"
+
+export const EasyEditorPanelView = view(use => ({
+		bindings,
+		eventTarget,
+		onResetDefaults,
+		onKeybindAssignment,
+	}: {
+		bindings: Bindings
+		eventTarget: EventTarget
+		onResetDefaults: () => void
+		onKeybindAssignment: AssignKeybind
+	}) => {
+
+	const [waiting, setWaiting]
+		= use.state<undefined | Waiting>(undefined)
+
+	const getWaiting = hackGetter(use, waiting)
+
+	use.setup(setupListenToInputsAndActuateKeyBindAssignment({
+		eventTarget,
+		getWaiting,
+		setWaiting,
+		onKeybindAssignment,
+	}))
+
+	return html`
+		<div data-panel=easy-editor>
+			<div class=keybindlist>
+				${Object
+					.entries(bindings["*️⃣"])
+					.map(renderKeybind(waiting, setWaiting))}
+			</div>
+
+			<div class=buttons>
+				<button @click=${onResetDefaults}>
+					${buttonLabels.resetDefaults}
+				</button>
+			</div>
+		</div>
+	`
+})

--- a/s/elements/bindings-editor/views/easy/hack-getter.ts
+++ b/s/elements/bindings-editor/views/easy/hack-getter.ts
@@ -1,0 +1,13 @@
+
+import {Use} from "@chasemoskal/magical/x/view/types.js"
+
+/**
+ * currently, magical view use.state doesn't provide a getter.
+ * this hack workaround provides a getter until a future version
+ * of magical can.
+ */
+export function hackGetter<X>(use: Use, x: X) {
+	const [hack] = use.state<{x: X}>({x: <X>undefined})
+	hack.x = x
+	return () => hack.x
+}

--- a/s/elements/bindings-editor/views/easy/keybind.ts
+++ b/s/elements/bindings-editor/views/easy/keybind.ts
@@ -2,9 +2,9 @@
 import {html} from "lit"
 import {view} from "@chasemoskal/magical/x/view/view.js"
 
-import {Waiting} from "../types.js"
-import {buttonLabels} from "../utils/constants.js"
-import {renderKeycap} from "../utils/render-keycap.js"
+import {Waiting} from "../../types.js"
+import {renderKeycap} from "./render-keycap.js"
+import {buttonLabels} from "../../utils/constants.js"
 
 export const KeybindView = view(use => ({
 		action,

--- a/s/elements/bindings-editor/views/easy/keycap.ts
+++ b/s/elements/bindings-editor/views/easy/keycap.ts
@@ -2,7 +2,7 @@
 import {html} from "lit"
 import {view} from "@chasemoskal/magical/x/view/view.js"
 
-import {buttonLabels} from "../utils/constants.js"
+import {buttonLabels} from "../../utils/constants.js"
 
 export const KeycapView = view(use => ({
 		code,

--- a/s/elements/bindings-editor/views/easy/render-keybind.ts
+++ b/s/elements/bindings-editor/views/easy/render-keybind.ts
@@ -1,8 +1,8 @@
 
 import {StateSetter} from "@chasemoskal/magical/x/view/types.js"
 
-import {Waiting} from "../types.js"
-import {KeybindView} from "../views/keybind.js"
+import {Waiting} from "../../types.js"
+import {KeybindView} from "./keybind.js"
 
 export function renderKeybind(
 		waiting: undefined | Waiting,

--- a/s/elements/bindings-editor/views/easy/render-keycap.ts
+++ b/s/elements/bindings-editor/views/easy/render-keycap.ts
@@ -1,6 +1,6 @@
 
-import {Waiting} from "../types.js"
-import {KeycapView} from "../views/keycap.js"
+import {Waiting} from "../../types.js"
+import {KeycapView} from "./keycap.js"
 
 export function renderKeycap({
 		waiting,

--- a/s/elements/bindings-editor/views/text-editor-panel.ts
+++ b/s/elements/bindings-editor/views/text-editor-panel.ts
@@ -1,0 +1,23 @@
+
+import {html} from "lit"
+import {view} from "@chasemoskal/magical/x/view/view.js"
+
+import {Bindings} from "../../../types.js"
+import {defaultBindingsText} from "../../context/parts/default-bindings.js"
+
+export const TextEditorPanelView = view(use => ({
+		bindings,
+	}: {
+		bindings: Bindings
+	}) => {
+
+	return html`
+		<div data-panel=text-editor>
+			<textarea>${bindingsToText(bindings)}</textarea>
+		</div>
+	`
+})
+
+export function bindingsToText(bindings: Bindings) {
+	return defaultBindingsText()
+}

--- a/s/elements/context/parts/default-bindings.ts
+++ b/s/elements/context/parts/default-bindings.ts
@@ -1,6 +1,21 @@
 
 import {Bindings} from "../../../types.js"
 
+export const defaultBindingsText = () => `
+👼 Cool Default Bindings
+🖱️ look :: lookmouse
+🕹️ look :: lookstick
+🕹️ move :: movestick
+*️⃣ forward :: KeyW ArrowUp
+*️⃣ backward :: KeyS ArrowDown
+*️⃣ leftward :: KeyA ArrowLeft
+*️⃣ rightward :: KeyD ArrowRight
+*️⃣ jump :: Space
+*️⃣ use :: KeyF Mouse3
+*️⃣ primary :: Mouse1
+*️⃣ secondary :: Mouse2
+`.trim()
+
 export const defaultBindings: Bindings = {
 	"👼": [
 		"Cool Default Bindings"


### PR DESCRIPTION
- add a new `text-editor-panel` view
- move the current keybindings logic into `easy-editor-panel` view
- thus, the nub-bindings-editor is then primarily comprised of these two panel views

i think the new separation of concerns between nub-binding-editor and easy-editor-panel has made the code in both much better than when they were together

fun fact -- while developing this, i found a bug in magical view... it's was gnarly, but it's now fixed in magical `v0.0.5`